### PR TITLE
syntax_sugar: add Highlight() function

### DIFF
--- a/syntax_sugar.go
+++ b/syntax_sugar.go
@@ -45,3 +45,9 @@ func BoldItalic(text string) string {
 func Code(text string) string {
 	return fmt.Sprintf("`%s`", text)
 }
+
+// Highlight return text with highlight format.
+// If you set text "Hello", it will be converted to "==Hello==".
+func Highlight(text string) string {
+	return fmt.Sprintf("==%s==", text)
+}

--- a/syntax_sugar_test.go
+++ b/syntax_sugar_test.go
@@ -110,3 +110,18 @@ func TestCode(t *testing.T) {
 		}
 	})
 }
+
+func TestHighlight(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success Highlight()", func(t *testing.T) {
+		t.Parallel()
+
+		want := "==Hello=="
+		got := Highlight("Hello")
+
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("value is mismatch (-want +got):\n%s", diff)
+		}
+	})
+}


### PR DESCRIPTION
In most Markdown processors, ==%s== is used to highlight text so that it will appear with a yellow background. See
https://www.codecademy.com/resources/docs/markdown/highlight for more information and an example.